### PR TITLE
@Scaffold Controller and Service support

### DIFF
--- a/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolver.groovy
+++ b/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolver.groovy
@@ -1,5 +1,6 @@
 package grails.plugin.scaffolding
 
+import grails.plugin.scaffolding.annotation.ScaffoldController
 import grails.codegen.model.ModelBuilder
 import grails.io.IOUtils
 import grails.util.BuildSettings
@@ -54,6 +55,14 @@ class ScaffoldingViewResolver extends GroovyPageViewResolver implements Resource
                 def controllerClass = webR.controllerClass
 
                 def scaffoldValue = controllerClass?.getPropertyValue("scaffold")
+                if (!scaffoldValue) {
+                    ScaffoldController scaffoldAnnotation = controllerClass?.clazz?.getAnnotation(ScaffoldController)
+                    scaffoldValue = scaffoldAnnotation?.domain()
+                    if (scaffoldValue == Void) {
+                        scaffoldValue = null
+                    }
+                }
+
                 if(scaffoldValue instanceof Class) {
                     def shortViewName = viewName.substring(viewName.lastIndexOf('/') + 1)
                     Resource res = null

--- a/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldController.java
+++ b/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldController.java
@@ -10,4 +10,5 @@ import java.lang.annotation.Target;
 public @interface ScaffoldController {
     Class<?> value() default Void.class;
     Class<?> domain() default Void.class;
+    boolean readOnly() default false;
 }

--- a/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldController.java
+++ b/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldController.java
@@ -1,0 +1,13 @@
+package grails.plugin.scaffolding.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ScaffoldController {
+    Class<?> value() default Void.class;
+    Class<?> domain() default Void.class;
+}

--- a/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldService.java
+++ b/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldService.java
@@ -1,0 +1,13 @@
+package grails.plugin.scaffolding.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ScaffoldService {
+    Class<?> value() default Void.class;
+    Class<?> domain() default Void.class;
+}

--- a/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldService.java
+++ b/grace-plugin-scaffolding/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldService.java
@@ -10,4 +10,5 @@ import java.lang.annotation.Target;
 public @interface ScaffoldService {
     Class<?> value() default Void.class;
     Class<?> domain() default Void.class;
+    boolean readOnly() default false;
 }

--- a/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
+++ b/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
@@ -2,6 +2,7 @@ package org.grails.compiler.scaffolding
 
 import grails.compiler.ast.AstTransformer
 import grails.compiler.ast.GrailsArtefactClassInjector
+import grails.plugin.scaffolding.annotation.ScaffoldController
 import grails.rest.RestfulController
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassHelper
@@ -13,6 +14,7 @@ import org.grails.compiler.injection.GrailsASTUtils
 import org.grails.compiler.web.ControllerActionTransformer
 import org.grails.core.artefact.ControllerArtefactHandler
 import org.grails.plugins.web.rest.transform.ResourceTransform
+
 /**
  * Transformation that turns a controller into a scaffolding controller at compile time of 'static scaffold = Foo'
  * is specified
@@ -41,22 +43,26 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
     @Override
     void performInjectionOnAnnotatedClass(SourceUnit source, ClassNode classNode) {
         def propertyNode = classNode.getProperty(PROPERTY_SCAFFOLD)
+        def annotationNode = classNode.getAnnotations(ClassHelper.make(ScaffoldController)).find()
 
         def expression = propertyNode?.getInitialExpression()
-        if(expression instanceof ClassExpression) {
-
-            ClassNode superClassNode = ClassHelper.make(RestfulController).getPlainNodeReference()
+        if (expression instanceof ClassExpression || annotationNode) {
+            ClassNode superClassNode = ClassHelper.make(annotationNode?.getMember("value")?.type?.getTypeClass()?:RestfulController).getPlainNodeReference()
             def currentSuperClass = classNode.getSuperClass()
-            if(currentSuperClass.equals( GrailsASTUtils.OBJECT_CLASS_NODE )) {
-                def domainClass = ((ClassExpression) expression).getType()
+            if (currentSuperClass.equals(GrailsASTUtils.OBJECT_CLASS_NODE)) {
+                def domainClass = expression? ((ClassExpression) expression).getType() : null
+                if (!domainClass) {
+                    domainClass = annotationNode.getMember("domain")?.type
+                    if (!domainClass) {
+                        GrailsASTUtils.error(source, classNode, "Scaffolded controller (${classNode.name}) with @ScaffoldController does not have domain class set.", true)
+                    }
+                }
                 classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
                 new ResourceTransform().addConstructor(classNode, domainClass, false)
-            }
-            else if( ! currentSuperClass.isDerivedFrom(superClassNode)) {
+            } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {
                GrailsASTUtils.error(source, classNode, "Scaffolded controllers (${classNode.name}) cannot extend other classes: ${currentSuperClass.getName()}", true)
             }
-        }
-        else if(propertyNode != null) {
+        } else if (propertyNode != null) {
             GrailsASTUtils.error(source, propertyNode, "The 'scaffold' property must refer to a domain class.", true)
         }
     }

--- a/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
+++ b/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
@@ -47,12 +47,20 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
 
         def expression = propertyNode?.getInitialExpression()
         if (expression instanceof ClassExpression || annotationNode) {
-            ClassNode superClassNode = ClassHelper.make(annotationNode?.getMember("value")?.type?.getTypeClass()?:RestfulController).getPlainNodeReference()
-            def currentSuperClass = classNode.getSuperClass()
+            ClassNode controllerClassNode = annotationNode?.getMember("value")?.type
+            ClassNode superClassNode = ClassHelper.make(controllerClassNode?.getTypeClass()?:RestfulController).getPlainNodeReference()
+            ClassNode currentSuperClass = classNode.getSuperClass()
             if (currentSuperClass.equals(GrailsASTUtils.OBJECT_CLASS_NODE)) {
                 def domainClass = expression? ((ClassExpression) expression).getType() : null
                 if (!domainClass) {
                     domainClass = annotationNode.getMember("domain")?.type
+                    if (!domainClass) {
+                        domainClass = extractGenericDomainClass(controllerClassNode)
+                        if (domainClass) {
+                            // set the domain value on the annotation so that ScaffoldingViewResolver can identify the domain object.
+                            annotationNode.addMember("domain", new ClassExpression(domainClass))
+                        }
+                    }
                     if (!domainClass) {
                         GrailsASTUtils.error(source, classNode, "Scaffolded controller (${classNode.name}) with @ScaffoldController does not have domain class set.", true)
                     }
@@ -65,6 +73,14 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
         } else if (propertyNode != null) {
             GrailsASTUtils.error(source, propertyNode, "The 'scaffold' property must refer to a domain class.", true)
         }
+    }
+
+    protected static ClassNode extractGenericDomainClass(ClassNode controllerClassNode) {
+        def genericsTypes = controllerClassNode?.genericsTypes
+        if (genericsTypes && genericsTypes.length > 0) {
+            return genericsTypes[0].type
+        }
+        return null
     }
 
     @Override

--- a/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
+++ b/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
@@ -8,6 +8,7 @@ import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.expr.ClassExpression
+import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codehaus.groovy.classgen.GeneratorContext
 import org.codehaus.groovy.control.SourceUnit
 import org.grails.compiler.injection.GrailsASTUtils
@@ -66,7 +67,8 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
                     }
                 }
                 classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
-                new ResourceTransform().addConstructor(classNode, domainClass, false)
+                def readOnlyExpression = (ConstantExpression) annotationNode.getMember("readOnly")
+                new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean()?:false)
             } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {
                GrailsASTUtils.error(source, classNode, "Scaffolded controllers (${classNode.name}) cannot extend other classes: ${currentSuperClass.getName()}", true)
             }

--- a/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
+++ b/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
@@ -6,6 +6,7 @@ import grails.plugin.scaffolding.annotation.ScaffoldService
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codehaus.groovy.classgen.GeneratorContext
 import org.codehaus.groovy.control.SourceUnit
 import org.grails.compiler.injection.GrailsASTUtils
@@ -57,7 +58,8 @@ class ScaffoldingServiceInjector implements GrailsArtefactClassInjector {
                     GrailsASTUtils.error(source, classNode, "Scaffolded service (${classNode.name}) with @ScaffoldService does not have domain class set.", true)
                 }
                 classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
-                new ResourceTransform().addConstructor(classNode, domainClass, false)
+                def readOnlyExpression = (ConstantExpression) annotationNode.getMember("readOnly")
+                new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean()?:false)
             } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {
                GrailsASTUtils.error(source, classNode, "Scaffolded services (${classNode.name}) cannot extend other classes: ${currentSuperClass.getName()}", true)
             }

--- a/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
+++ b/grace-plugin-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
@@ -1,0 +1,71 @@
+package org.grails.compiler.scaffolding
+
+import grails.compiler.ast.AstTransformer
+import grails.compiler.ast.GrailsArtefactClassInjector
+import grails.plugin.scaffolding.annotation.ScaffoldService
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.classgen.GeneratorContext
+import org.codehaus.groovy.control.SourceUnit
+import org.grails.compiler.injection.GrailsASTUtils
+import org.grails.core.artefact.ServiceArtefactHandler
+import org.grails.io.support.GrailsResourceUtils
+import org.grails.plugins.web.rest.transform.ResourceTransform
+
+import java.util.regex.Pattern
+
+/**
+ * Transformation that turns a service into a scaffolding service at compile time if '@ScaffoldService'
+ * is specified
+ *
+ * @author Scott Murphy Heiberg
+ * @since 5.1
+ */
+@AstTransformer
+@CompileStatic
+class ScaffoldingServiceInjector implements GrailsArtefactClassInjector {
+
+    final String[] artefactTypes = [ServiceArtefactHandler.TYPE] as String[]
+    public static Pattern SERVICE_PATTERN = Pattern.compile(".+/" +
+        GrailsResourceUtils.GRAILS_APP_DIR + "/services/(.+)Service\\.groovy");
+
+    @Override
+    void performInjection(SourceUnit source, GeneratorContext context, ClassNode classNode) {
+        performInjectionOnAnnotatedClass(source, classNode)
+    }
+
+    @Override
+    void performInjection(SourceUnit source, ClassNode classNode) {
+        performInjectionOnAnnotatedClass(source, classNode)
+    }
+
+    @Override
+    void performInjectionOnAnnotatedClass(SourceUnit source, ClassNode classNode) {
+        def annotationNode = classNode.getAnnotations(ClassHelper.make(ScaffoldService)).find()
+        if (annotationNode) {
+            ClassNode serviceClassNode = annotationNode?.getMember("value")?.type
+            Class serviceClass = serviceClassNode?.getTypeClass()
+            ClassNode superClassNode = ClassHelper.make(serviceClass).getPlainNodeReference()
+            ClassNode currentSuperClass = classNode.getSuperClass()
+            if (currentSuperClass.equals(GrailsASTUtils.OBJECT_CLASS_NODE)) {
+                def domainClass = annotationNode.getMember("domain")?.type
+                if (!domainClass) {
+                    domainClass = ScaffoldingControllerInjector.extractGenericDomainClass(serviceClassNode)
+                }
+                if (!domainClass) {
+                    GrailsASTUtils.error(source, classNode, "Scaffolded service (${classNode.name}) with @ScaffoldService does not have domain class set.", true)
+                }
+                classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
+                new ResourceTransform().addConstructor(classNode, domainClass, false)
+            } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {
+               GrailsASTUtils.error(source, classNode, "Scaffolded services (${classNode.name}) cannot extend other classes: ${currentSuperClass.getName()}", true)
+            }
+        }
+    }
+
+    @Override
+    boolean shouldInject(URL url) {
+        return url != null && SERVICE_PATTERN.matcher(url.getFile()).find()
+    }
+}


### PR DESCRIPTION
Adds support for the annotation`@ScaffoldController` which provides an alternative to the `static scaffold = Domain` approach. 
```groovy
@ScaffoldController(domain = User)
class UserController {}
```

It also empowers the developer to use their own base controller instead of being forced to use `RestController` which could be very limiting.  `RestController` does not encapsulate all necessary business logic and is completely divergent from the Service MVC model that is generated by this plugin.  With this annotation, developers can now use an extended RestController to fit their needs, or create an entirely different generic controller that is not related at all to RestController and more closely matches the type of controller that is generated by this plugin.

```groovy
@ScaffoldController(GenericAsyncController)
class UserController {
    static scaffold = User
}
```

```groovy
@ScaffoldController(value = SecuredGenericController, domain = User)
class UserController {}
```

https://github.com/grails/scaffolding/issues/113